### PR TITLE
Feature/#6: deck logs

### DIFF
--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -10,7 +10,7 @@ from src.settings import UNIKUBE_FILE
 from src.unikubefile.selector import unikube_file_selector
 
 
-def get_required_information(ctx, project_title: str, deck_title: str):
+def get_deck_from_arguments(ctx, project_title: str, deck_title: str):
     ## project_id
     cluster_list = ctx.cluster_manager.get_cluster_list(ready=True)
     cluster_title_list = [item.name for item in cluster_list]
@@ -121,7 +121,7 @@ def shell(ctx, project_title, deck_title, pod_title, **kwargs):
 
     ctx.auth.check()
 
-    project_id, project_title, deck = get_required_information(ctx, project_title, deck_title)
+    project_id, project_title, deck = get_deck_from_arguments(ctx, project_title, deck_title)
 
     ## shell
     # check if cluster is ready
@@ -188,7 +188,7 @@ def switch(ctx, project_title, deck_title, deployment, image, unikubefile, **kwa
 
     ctx.auth.check()
 
-    project_id, project_title, deck = get_required_information(ctx, project_title, deck_title)
+    project_id, project_title, deck = get_deck_from_arguments(ctx, project_title, deck_title)
 
     ## switch
     # check if cluster is ready
@@ -311,7 +311,7 @@ def logs(ctx, project_title, deck_title, pod_title, follow=False, **kwargs):
 
     ctx.auth.check()
 
-    project_id, project_title, deck = get_required_information(ctx, project_title, deck_title)
+    project_id, project_title, deck = get_deck_from_arguments(ctx, project_title, deck_title)
 
     ## logs
     # check if cluster is ready

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -304,10 +304,9 @@ def pulldb(**kwargs):
 @click.argument("project_title", required=False)
 @click.argument("deck_title", required=False)
 @click.argument("pod_title", required=False)
-@click.argument("pod_title", required=False)
-@click.option("--watch", "-w", is_flag=True, default=False, help="Watch logs.")
+@click.option("--follow", "-f", is_flag=True, default=False, help="Follow logs.")
 @click.pass_obj
-def logs(ctx, project_title, deck_title, pod_title, watch, **kwargs):
+def logs(ctx, project_title, deck_title, pod_title, follow=False, **kwargs):
     """Display the container's logs"""
 
     ctx.auth.check()
@@ -338,7 +337,7 @@ def logs(ctx, project_title, deck_title, pod_title, watch, **kwargs):
         console.error("No pods available.")
         return None
 
-    logs = k8s.get_logs(pod_title, watch)
+    logs = k8s.get_logs(pod_title, follow)
 
     # output
     click.echo(logs)

--- a/src/cli/deck.py
+++ b/src/cli/deck.py
@@ -2,7 +2,7 @@ import click
 from requests import HTTPError
 
 import src.cli.console as console
-from src.cli.app import get_required_information
+from src.cli.app import get_deck_from_arguments
 from src.cli.console.logger import LogLevel, color_mapping
 from src.graphql import EnvironmentType, GraphQL
 from src.helpers import download_specs
@@ -402,7 +402,7 @@ def logs(ctx, project_title, deck_title, **kwargs):
 
     ctx.auth.check()
 
-    project_id, project_title, deck = get_required_information(ctx, project_title, deck_title)
+    project_id, project_title, deck = get_deck_from_arguments(ctx, project_title, deck_title)
 
     ## logs
     # check if cluster is ready

--- a/src/cli/deck.py
+++ b/src/cli/deck.py
@@ -393,7 +393,7 @@ def uninstall(deck_name, **kwargs):
 
 @click.command()
 @click.argument("deck_name", required=False)
-@click.option("--app", "-a", help="Stream aggregated logs")
+@click.option("--follow", "-f", is_flag=True, default=False, help="Follow logs.")
 def logs(deck_name, **kwargs):
     raise NotImplementedError
 


### PR DESCRIPTION
This is the  basic implementation of the command `deck logs`. Howerver I'm not sure how to implement the "follow" option on a deck level. It is possible to follow logs of one pod by using `unikube app logs -f`.

Is the follow option required for decks?