### PR TITLE
chore: bump gql

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ python-slugify~=5.0.2
 requests~=2.25.1
 pyjwt[crypto]~=2.0.1
 
-gql~=0.4.0
+gql~=2.0.0
 semantic-version~=2.8.4
 kubernetes>=11.0.0
 retrying~=1.3.3

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "tinydb~=3.15.2",
         "requests~=2.25.1",
         "pyjwt[crypto]~=2.0.1",
-        "gql~=0.4.0",
+        "gql~=2.0.0",
         "semantic-version~=2.8.4",
         "kubernetes>=11.0.0",
         "retrying~=1.3.3",


### PR DESCRIPTION
Reason:

The wheel and tar package for version 0.4.0 on Pypi contain different contents, which leads to a broken cli when installing via `brew`.