### PR TITLE
feat: add generation for bash completion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ To install the latest (pre-)release of the Unikube CLI type
 sudo pip3 install unikube==<VERSION> --upgrade --pre
 ```
 
+#### Enable tab completion
+
+`unikube` support tab completion scripts for bash.
+
+```shell
+unikube system completion bash > /etc/bash_completion.d/unikube.bash-completion
+```
+
+You probably need to restart your shell in order for the completion script to do its work.
+
 ### Virtual Environment + Requirements
 
 Create virtual environment:

--- a/src/cli/system.py
+++ b/src/cli/system.py
@@ -4,7 +4,6 @@ import sys
 import click
 
 import src.cli.console as console
-from src.completion.completion import render_completion_script
 from src.helpers import compare_current_and_latest_versions
 from src.local.dependency import install_dependency, probe_dependencies
 
@@ -111,15 +110,3 @@ def verify(verbose):
     console.success("Local dependencies verified.")
 
     return True
-
-
-@click.command()
-@click.argument("shell", required=True)
-def completion(shell):
-    """
-    Generate tab completion script for a given shell.
-    Supported shells: bash.
-    """
-    from unikube import cli
-
-    render_completion_script(cli, shell)

--- a/src/cli/system.py
+++ b/src/cli/system.py
@@ -2,10 +2,9 @@ import os
 import sys
 
 import click
-from tabulate import tabulate
 
 import src.cli.console as console
-from src import settings
+from src.completion.completion import render_completion_script
 from src.helpers import compare_current_and_latest_versions
 from src.local.dependency import install_dependency, probe_dependencies
 
@@ -112,3 +111,15 @@ def verify(verbose):
     console.success("Local dependencies verified.")
 
     return True
+
+
+@click.command()
+@click.argument("shell", required=True)
+def completion(shell):
+    """
+    Generate tab completion script for a given shell.
+    Supported shells: bash.
+    """
+    from unikube import cli
+
+    render_completion_script(cli, shell)

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -1,0 +1,173 @@
+import textwrap
+from typing import List
+
+import click
+
+from src.cli import console
+
+from .templates import TEMPLATES
+
+
+def align_spacing(string: str, spaces: int) -> str:
+    """
+    Prefix multiline string with given number of spaces.
+
+    Just a helper to make the scripts more readable.
+    """
+    return textwrap.indent(textwrap.dedent(string), " " * spaces)
+
+
+def get_subcommands(command: dict) -> dict:
+    """Extract subcommands from Click's information dictionary retrieved via `to_info_dict`."""
+    if "commands" in command:
+        commands = command["commands"]
+        return {key: get_options(command["commands"][key]) for key in commands.keys()}
+    return {}
+
+
+def get_options(command: dict) -> List[str]:
+    """Extract options from Click's information dictionary retrieved via `to_info_dict`."""
+    params = command["params"]
+    result = []
+    for param in params:
+        result.extend(filter(lambda x: "--" in x, param["opts"]))
+    return result
+
+
+def render_subcommand_completion(current_command: str, commands: List):
+    """Renders case statement for subcommand completion."""
+    return """
+    ({current_command})
+        coms="{commands}"
+        COMPREPLY=($(compgen -W "${{coms}}" -- ${{cur}}))
+        __ltrim_colon_completions "$cur"
+        return 0;
+        ;;
+    """.format(
+        current_command=current_command, commands=" ".join(commands)
+    )
+
+
+def render_options_case(command: str, func_name: str):
+    """Renders case statement (function call) for options completion."""
+    return align_spacing(
+        """
+        ({command})
+            {func_name}
+            ;;""".format(
+            command=command, func_name=func_name
+        ),
+        12,
+    )
+
+
+def render_command_options(command: str, options: List[str]) -> str:
+    """Generate bash option string for a command."""
+    return """
+        ({command})
+            opts="${{opts}} {options}"
+            ;;""".format(
+        command=command, options=" ".join(options)
+    )
+
+
+def render_flag_completion_func(command_dict: dict, name: str) -> (str, str):
+    """Renders function for flag completion of command and its subcommands."""
+    subcommands = get_subcommands(command_dict)
+    options = get_options(command_dict)
+
+    func_name = "__unikube_complete_flags_{name}".format(name=name)
+
+    if subcommands:
+        subcommand_cases = align_spacing(
+            "\n".join([render_command_options(c[0], c[1]) for c in subcommands.items()]), 16
+        )
+
+        return func_name, align_spacing(
+            """
+        {func_name}() {{
+            if [[ $com == $prev ]]; then
+                opts="${{opts}} {options}"
+            else
+                case "$prev" in
+                    {subcommand_cases}
+                esac
+            fi
+        }}
+        """.format(
+                func_name=func_name, options=" ".join(options), subcommand_cases=subcommand_cases
+            ),
+            0,
+        )
+    return func_name, align_spacing(
+        """
+    {func_name}() {{
+        opts="${{opts}} {options}"
+    }}
+    """.format(
+            func_name=func_name,
+            options=" ".join(options),
+        ),
+        0,
+    )
+
+
+def render_bash(cli):
+    """Renders bash completion script and prints it."""
+    with click.Context(cli) as ctx:
+        info = ctx.to_info_dict()
+
+        template = TEMPLATES["bash"]
+
+        # static information for rendering
+        # could be dynamic in the future (e.g. for aliases)
+        function = "_unikube_complete"
+        aliases = ["unikube"]
+        compdefs = "\n".join(["complete -o default -F {} {}".format(function, alias) for alias in aliases])
+
+        # Based on click's info dict retrieve information about commands and flags.
+        # These are then used to render certain parts of the completion.
+        commands = info["command"]["commands"].keys()
+        command_list = []
+        subcommands = []
+        functions = []
+        for command in commands:
+            subs = get_subcommands(info["command"]["commands"][command])
+            name, func = render_flag_completion_func(info["command"]["commands"][command], command)
+            desc = []
+            if name and func:
+                functions.append(func)
+                desc = [render_options_case(command, name)]
+
+            if len(subs.keys()):
+                subcommands.append(render_subcommand_completion(command, list(subs.keys())))
+
+            if len(desc):
+                command_list.append("\n".join(desc))
+
+        # Render template with all retrieved information.
+        output = template.format(
+            function=function,
+            flag_complete_functions="\n".join(functions),
+            opts=" ".join(sorted([])),
+            coms=" ".join(commands),
+            command_list="\n".join(command_list),
+            compdefs=compdefs,
+            subcommands="\n".join(subcommands),
+        )
+
+        console.echo(output)
+
+
+def render_completion_script(cli, shell: str):
+    """Renders a completion for a given shell."""
+    SUPPORTED_SHELLS = ["bash"]
+
+    if shell not in SUPPORTED_SHELLS:
+        console.error(
+            "{} is not supported. Following shells are supported: {}.".format(shell, ", ".join(SUPPORTED_SHELLS)),
+            _exit=True,
+        )
+
+    if shell == "bash":
+        render_bash(cli)

--- a/src/completion/templates.py
+++ b/src/completion/templates.py
@@ -1,0 +1,107 @@
+# Heavily inspired by the cleo project. Check it out.
+# https://github.com/sdispater/cleo
+# We use double curly braces to "escape" curly braces.
+# Templates are rendered using Python's built-in `format` method for strings.
+
+
+BASH_TEMPLATE = """{flag_complete_functions}
+{function}()
+{{
+    local cur script coms opts com
+    COMPREPLY=()
+    _get_comp_words_by_ref -n : cur prev words
+    # for an alias, get the real script behind it
+    if [[ $(type -t ${{words[0]}}) == "alias" ]]; then
+        script=$(alias ${{words[0]}} | sed -E "s/alias ${{words[0]}}='(.*)'/\\1/")
+    else
+        script=${{words[0]}}
+    fi
+    # lookup for command
+    for word in ${{words[@]:1}}; do
+        if [[ $word != -* ]]; then
+            com=$word
+            break
+        fi
+    done
+
+    # completing for an option
+    if [[ ${{cur}} == --* ]] ; then
+        opts="{opts}"
+        case "$com" in
+{command_list}
+        esac
+        COMPREPLY=($(compgen -W "${{opts}}" -- ${{cur}}))
+        __ltrim_colon_completions "$cur"
+        return 0;
+    fi
+
+    if [[ $prev == $com ]]; then
+        case "$com" in
+            {subcommands}
+        esac
+    fi
+
+    # completing for a command
+    if [[ $cur == $com ]]; then
+        coms="{coms}"
+        COMPREPLY=($(compgen -W "${{coms}}" -- ${{cur}}))
+        __ltrim_colon_completions "$cur"
+        return 0
+    fi
+}}
+{compdefs}"""
+
+ZSH_TEMPLATE = """#compdef %(script_name)s
+%(function)s()
+{
+    local state com cur
+    cur=${words[${#words[@]}]}
+    # lookup for command
+    for word in ${words[@]:1}; do
+        if [[ $word != -* ]]; then
+            com=$word
+            break
+        fi
+    done
+    if [[ ${cur} == --* ]]; then
+        state="option"
+        opts=(%(opts)s)
+    elif [[ $cur == $com ]]; then
+        state="command"
+        coms=(%(coms)s)
+    fi
+    case $state in
+        (command)
+            _describe 'command' coms
+        ;;
+        (option)
+            case "$com" in
+%(command_list)s
+            esac
+            _describe 'option' opts
+        ;;
+        *)
+            # fallback to file completion
+            _arguments '*:file:_files'
+    esac
+}
+%(function)s "$@"
+%(compdefs)s"""
+
+FISH_TEMPLATE = """function __fish%(function)s_no_subcommand
+    for i in (commandline -opc)
+        if contains -- $i %(cmds_names)s
+            return 1
+        end
+    end
+    return 0
+end
+# global options
+%(opts)s
+# commands
+%(cmds)s
+# command options
+%(cmds_opts)s"""
+
+
+TEMPLATES = {"bash": BASH_TEMPLATE, "zsh": ZSH_TEMPLATE, "fish": FISH_TEMPLATE}

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -1,0 +1,18 @@
+import unittest
+
+from click.testing import CliRunner
+
+from unikube import ClickContext, completion
+
+
+class CompletionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.runner = CliRunner()
+
+    def test_no_cluster(self):
+        result = self.runner.invoke(
+            completion,
+            ["bash"],
+            obj=ClickContext(),
+        )
+        self.assertEqual(result.exit_code, 0)

--- a/unikube.py
+++ b/unikube.py
@@ -72,10 +72,21 @@ def system(ctx):
     """
 
 
+@click.command()
+@click.argument("shell", required=True)
+def completion(shell):
+    """
+    Generate tab completion script for a given shell.
+    Supported shells: bash.
+    """
+
+    render_completion_script(cli, shell)
+
+
 # system
 system.add_command(system_cmd.install)
 system.add_command(system_cmd.verify)
-system.add_command(system_cmd.completion)
+system.add_command(completion)
 
 
 # organization

--- a/unikube.py
+++ b/unikube.py
@@ -12,6 +12,7 @@ from src.cli import orga as orga_cmd
 from src.cli import project as project_cmd
 from src.cli import system as system_cmd
 from src.cli import unikube as unikube_cmd
+from src.completion.completion import render_completion_script
 from src.context import ClickContext
 from src.helpers import compare_current_and_latest_versions
 
@@ -74,6 +75,7 @@ def system(ctx):
 # system
 system.add_command(system_cmd.install)
 system.add_command(system_cmd.verify)
+system.add_command(system_cmd.completion)
 
 
 # organization


### PR DESCRIPTION
Adds generation for bash completion script.
Also adds templates for zsh and fish (not done).

Still needs some refinement (uses print statement, maybe add some hints to the docs, some code style changes)...

Maybe we should use jinja2 or something to make the rendering a bit nicer?

When done - closes #158 