### PR TITLE
chore: add spinner during auth / graphql queries

### DIFF
--- a/src/authentication/authentication.py
+++ b/src/authentication/authentication.py
@@ -1,5 +1,7 @@
+import sys
 from urllib.parse import urljoin
 
+import click_spinner
 import jwt
 import requests
 
@@ -88,8 +90,9 @@ class TokenAuthentication(IAuthentication):
 
     def check(self):
         # login required
-        if not self.verify_or_refresh():
-            console.exit_login_required()
+        with click_spinner.spinner(beep=False, disable=False, force=False, stream=sys.stdout):
+            if not self.verify_or_refresh():
+                console.exit_login_required()
 
     def login(
         self,


### PR DESCRIPTION
I looked into #226

For once - it seems the spinner functionality was removed from the package and will be reimplemented (https://github.com/kazhala/InquirerPy/commit/0d39efa446f51ff75a38dd66bf8a0b91f67332c8)

However, when investigating the waiting times a bit more - turns out for most things its our GraphQL queries and the auth causing some "blank" waiting time.

Therefore I added `click_spinner` for auth and GraphQL queries.

Closes #226 