### PR TITLE
feat: add check for availability of cluster port before `project up`

### DIFF
--- a/src/cli/helper.py
+++ b/src/cli/helper.py
@@ -22,7 +22,7 @@ def check_ports(port_list: List[int]):
 
     Returns a list of ports which are busy.
     """
-    return list(filter(lambda port: port_in_use(port), port_list))
+    return list(filter(port_in_use, port_list))
 
 
 def exist_or_create(folder):

--- a/src/cli/helper.py
+++ b/src/cli/helper.py
@@ -1,5 +1,28 @@
 import errno
 import os
+import socket
+from typing import List
+
+
+def port_in_use(port: int):
+    """
+    Checks whether a port is available on the local system.
+    """
+    a_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    location = ("127.0.0.1", port)
+    result_of_check = a_socket.connect_ex(location)
+
+    return result_of_check == 0
+
+
+def check_ports(port_list: List[int]):
+    """
+    Takes a list of integers and check whether those ports are available.
+
+    Returns a list of ports which are busy.
+    """
+    return list(filter(lambda port: port_in_use(port), port_list))
 
 
 def exist_or_create(folder):

--- a/src/cli/project.py
+++ b/src/cli/project.py
@@ -6,6 +6,7 @@ import click_spinner
 
 import src.cli.console as console
 from src import settings
+from src.cli.helper import check_ports
 from src.graphql import GraphQL
 from src.helpers import check_running_cluster
 from src.local.providers.types import K8sProviderType
@@ -219,6 +220,14 @@ def up(ctx, project=None, organization=None, ingress=None, provider=None, worker
     # get project id
     if ingress is None:
         ingress = project_selected["clusterSettings"]["port"]
+
+    if not_available_ports := check_ports([ingress]):
+        console.error(
+            "Following ports are currently busy, however needed to spin up the cluster: {}".format(
+                ", ".join([str(port) for port in not_available_ports])
+            ),
+            _exit=True,
+        )
 
     # cluster up
     cluster_data = ctx.cluster_manager.get(id=project_selected["id"])


### PR DESCRIPTION
Fixes #241 

Adds a simple check for the availability of the cluster port retrieved via GraphQL. 