### PR TITLE
feat(#239): app switch app argument

### DIFF
--- a/src/unikubefile/selector.py
+++ b/src/unikubefile/selector.py
@@ -1,9 +1,16 @@
+import os
 from typing import Union
 
 import click
 import yaml
 
-from src.unikubefile.unikube_file import UnikubeFile, UnikubeFileNotFoundError, UnikubeFileVersionError
+from src.settings import UNIKUBE_FILE
+from src.unikubefile.unikube_file import (
+    UnikubeFile,
+    UnikubeFileError,
+    UnikubeFileNotFoundError,
+    UnikubeFileVersionError,
+)
 from src.unikubefile.unikube_file_1_0 import UnikubeFile_1_0
 
 
@@ -11,7 +18,21 @@ class UnikubeFileSelector:
     def __init__(self, options: dict):
         self.options = options
 
-    def get(self, path_unikube_file: str) -> Union[UnikubeFile, UnikubeFile_1_0, None]:
+    @staticmethod
+    def __convert_apps_to_list(path_unikube_file: str, data: dict):
+        apps_list = []
+        for name, item in data["apps"].items():
+            item["unikube_file"] = path_unikube_file
+            item["name"] = name
+            apps_list.append(item)
+        data["apps"] = apps_list
+        return data
+
+    def get(self, path_unikube_file: str = None) -> Union[UnikubeFile, UnikubeFile_1_0, None]:
+        # default file path
+        if not path_unikube_file:
+            path_unikube_file = os.path.join(os.getcwd(), UNIKUBE_FILE)
+
         # load unikube file + get version
         try:
             with click.open_file(path_unikube_file) as unikube_file:
@@ -19,17 +40,22 @@ class UnikubeFileSelector:
         except FileNotFoundError:
             raise UnikubeFileNotFoundError
 
-        version = data.get("version", "latest")
+        # add & format data
+        try:
+            data = self.__convert_apps_to_list(path_unikube_file=path_unikube_file, data=data)
+        except Exception:
+            raise UnikubeFileError("Invalid unikube file.")
+
+        # version
+        version = str(data.get("version", "latest"))
+        data["version"] = version
 
         # get class
         unikube_file_class = self.options.get(version)
         if not unikube_file_class:
             raise UnikubeFileVersionError
 
-        return unikube_file_class(
-            path=path_unikube_file,
-            data=data,
-        )
+        return unikube_file_class(**data)
 
 
 unikube_file_selector = UnikubeFileSelector(

--- a/src/unikubefile/unikube_file.py
+++ b/src/unikubefile/unikube_file.py
@@ -16,9 +16,6 @@ class UnikubeFileError(Exception):
 
 
 class UnikubeFile(ABC):
-    def __init__(self, path: str, data: dict):
-        pass
-
     @abstractmethod
     def get_context(self) -> ContextData:
         raise NotImplementedError

--- a/src/unikubefile/unikube_file_1_0.py
+++ b/src/unikubefile/unikube_file_1_0.py
@@ -101,8 +101,8 @@ class UnikubeFile_1_0(UnikubeFile, BaseModel):
         for app in self.apps:
             if app.name == name:
                 return app
-        else:
-            if name != "default":
-                raise Exception("Invalid name.")
 
-            return self.apps[0]
+        if name != "default":
+            raise ValueError("Invalid name.")
+
+        return self.apps[0]

--- a/tests/unikube_file/test_unikube_file.py
+++ b/tests/unikube_file/test_unikube_file.py
@@ -1,0 +1,78 @@
+import os
+import unittest
+
+from src.unikubefile.selector import unikube_file_selector
+from src.unikubefile.unikube_file import UnikubeFileError
+
+
+class SelectorTest(unittest.TestCase):
+    def test_version_latest(self):
+        path_unikube_file = "tests/unikube_file/unikube_version_latest.yaml"
+        unikube_file = unikube_file_selector.get(path_unikube_file)
+        self.assertEqual("latest", unikube_file.version)
+
+    def test_version_1(self):
+        path_unikube_file = "tests/unikube_file/unikube_version_1.yaml"
+        unikube_file = unikube_file_selector.get(path_unikube_file)
+        self.assertEqual("1", unikube_file.version)
+
+    def test_apps_invalid(self):
+        path_unikube_file = "tests/unikube_file/unikube_apps_invalid.yaml"
+        with self.assertRaises(UnikubeFileError):
+            _ = unikube_file_selector.get(path_unikube_file)
+
+
+class UnikubeFileTest(unittest.TestCase):
+    def test_get_app_none(self):
+        path_unikube_file = "tests/unikube_file/unikube.yaml"
+        unikube_file = unikube_file_selector.get(path_unikube_file)
+
+        unikube_file_app = unikube_file.get_app()
+        self.assertEqual("your-app-01", unikube_file_app.name)
+
+    def test_get_app_name(self):
+        path_unikube_file = "tests/unikube_file/unikube.yaml"
+        unikube_file = unikube_file_selector.get(path_unikube_file)
+
+        unikube_file_app = unikube_file.get_app(name="your-app-01")
+        self.assertEqual("your-app-01", unikube_file_app.name)
+
+    def test_get_app_default(self):
+        path_unikube_file = "tests/unikube_file/unikube_apps_default.yaml"
+        unikube_file = unikube_file_selector.get(path_unikube_file)
+
+        unikube_file_app = unikube_file.get_app()
+        self.assertEqual("default", unikube_file_app.name)
+
+
+class UnikubeFileAppTest(unittest.TestCase):
+    def setUp(self) -> None:
+        path_unikube_file = "tests/unikube_file/unikube.yaml"
+        unikube_file = unikube_file_selector.get(path_unikube_file)
+        self.unikube_file_app = unikube_file.get_app()
+
+    def test_get_docker_build(self):
+        context, dockerfile, target = self.unikube_file_app.get_docker_build()
+        self.assertEqual(os.path.abspath(os.path.join(os.getcwd(), "tests/unikube_file/.")), context)
+        self.assertEqual("tests/unikube_file/Dockerfile", dockerfile)
+        self.assertEqual("target", target)
+
+    def test_get_command(self):
+        command = self.unikube_file_app.get_command()
+        self.assertEqual("bash".split(" "), command)
+
+    def test_get_port(self):
+        port = self.unikube_file_app.get_port()
+        self.assertEqual(str(8000), port)
+
+    def test_get_deployment(self):
+        deployment = self.unikube_file_app.get_deployment()
+        self.assertEqual("deployment", deployment)
+
+    def test_get_mounts(self):
+        volumes = self.unikube_file_app.get_mounts()
+        self.assertEqual([(os.path.abspath(os.path.join(os.getcwd(), "tests/unikube_file/src")), "/app")], volumes)
+
+    def test_get_environment(self):
+        env = self.unikube_file_app.get_environment()
+        self.assertEqual([("VARIABLE-01", "variable-01")], env)

--- a/tests/unikube_file/unikube.yaml
+++ b/tests/unikube_file/unikube.yaml
@@ -1,0 +1,13 @@
+apps:
+  your-app-01:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: target
+    deployment: deployment
+    port: 8000
+    command: bash
+    volumes:
+      - ./src:/app
+    env:
+      - VARIABLE-01: "variable-01"

--- a/tests/unikube_file/unikube_apps_default.yaml
+++ b/tests/unikube_file/unikube_apps_default.yaml
@@ -1,0 +1,16 @@
+apps:
+  your-app-01:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    deployment: test
+    command: bash
+
+  default:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    deployment: test
+    command: bash

--- a/tests/unikube_file/unikube_apps_invalid.yaml
+++ b/tests/unikube_file/unikube_apps_invalid.yaml
@@ -1,0 +1,3 @@
+version: 1
+
+apps:

--- a/tests/unikube_file/unikube_version_1.yaml
+++ b/tests/unikube_file/unikube_version_1.yaml
@@ -1,0 +1,10 @@
+version: 1
+
+apps:
+  projects:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    deployment: test
+    command: bash

--- a/tests/unikube_file/unikube_version_latest.yaml
+++ b/tests/unikube_file/unikube_version_latest.yaml
@@ -1,0 +1,8 @@
+apps:
+  projects:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    deployment: test
+    command: bash


### PR DESCRIPTION
- added possibility to define several apps to be switched in one unikube file.
- added app switch selection support to switch defined app from the unikube file
- added tests

Closes #239 main issue.

PS: I am not sure if/why we need the "--deployment" option. Currently the deployment option is required in the unikube.yaml . Maybe we can remove the "--deployment" option if its not required/used.

---

`unikube app switch` -> uses "default" key under apps, if available. Otherwise it uses the first entry.
`unikube app switch web` -> uses "web" key under apps, if available. Otherwise it throws an error.