### PR TITLE
fix: app list trace

### DIFF
--- a/unikube/cli/app.py
+++ b/unikube/cli/app.py
@@ -128,12 +128,12 @@ def list(ctx, organization, project, deck, **kwargs):
 
     def _ready_ind(c) -> Tuple[bool, str]:
         # get container count
-        if not c:
+        if c is None:
             container_count = 0
+            ready_count = 0
         else:
             container_count = len(c)
-
-        ready_count = sum([val.ready for val in c])
+            ready_count = sum([val.ready for val in c])
         return container_count == ready_count, f"{ready_count}/{container_count}"
 
     for pod in k8s.get_pods().items:


### PR DESCRIPTION
I had this trace:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/.../workspace/unikube/cli/unikube/__main__.py", line 4, in <module>
    cli()
  File "/home/.../workspace/unikube/cli/venv/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/.../workspace/unikube/cli/venv/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/.../workspace/unikube/cli/venv/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/.../workspace/unikube/cli/venv/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/.../workspace/unikube/cli/venv/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/.../workspace/unikube/cli/venv/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/.../workspace/unikube/cli/venv/lib/python3.8/site-packages/click/decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/home/.../workspace/unikube/cli/unikube/cli/app.py", line 142, in list
    all_ready, count = _ready_ind(pod.status.container_statuses)
  File "/home/.../workspace/unikube/cli/unikube/cli/app.py", line 136, in _ready_ind
    ready_count = sum([val.ready for val in c])
TypeError: 'NoneType' object is not iterable
```