### PR TITLE
fix(#268): centralize version determination

### DIFF
--- a/unikube/commands.py
+++ b/unikube/commands.py
@@ -40,16 +40,6 @@ def version():
     Check unikube version.
     """
     version = compare_current_and_latest_versions()
-    if not version:
-        try:
-            import pkg_resources
-        except ImportError:
-            pass
-        else:
-            dist = pkg_resources.working_set.by_key.get("unikube")
-            if dist:
-                version = dist.version
-
     if version is None:
         console.error("Could not determine version.")
 

--- a/unikube/helpers.py
+++ b/unikube/helpers.py
@@ -117,7 +117,13 @@ def compare_current_and_latest_versions():
             with path.open("r") as f:
                 current_version = f.read()
         except (FileNotFoundError, PermissionError):
-            console.warning("Could not read current version.")
+            console.debug("Could not read current version.")
+
+        if not current_version:
+            dist = pkg_resources.working_set.by_key.get("unikube")
+            if dist:
+                current_version = dist.version
+
         release = requests.get("https://api.github.com/repos/unikubehq/cli/releases/latest")
         if release.status_code == 403:
             console.info("Versions cannot be compared, as API rate limit was exceeded")


### PR DESCRIPTION
Fixes strange behaviour of `unikube version`.
<img width="584" alt="Bildschirmfoto 2022-02-22 um 23 39 43" src="https://user-images.githubusercontent.com/1231105/155231579-6d1ca0d9-1a39-431f-a61c-4b5c40f920a6.png">
Fixes #286 